### PR TITLE
Normalize path before perform any action with fs

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -2,6 +2,9 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+
+var normalize = require('path').normalize;
+
 function MemoryFileSystem(data) {
 	this.data = data || {};
 }
@@ -18,6 +21,7 @@ function isFile(item) {
 }
 
 function pathToArray(path) {
+	path = normalize(path);
 	var nix = /^\//.test(path);
 	if(!nix) {
 		if(!/^[A-Za-z]:/.test(path)) throw new Error("Invalid path '" + path + "'");


### PR DESCRIPTION
Without it paths /test/./test and /test/test are different, but they are not.