### PR TITLE
Add an `exists` and `existsSync` method.

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -196,7 +196,7 @@ MemoryFileSystem.prototype.normalize = normalize;
 
 // async functions
 
-["exists", "stat", "readdir", "mkdirp", "mkdir", "rmdir", "unlink", "readlink"].forEach(function(fn) {
+["stat", "readdir", "mkdirp", "mkdir", "rmdir", "unlink", "readlink"].forEach(function(fn) {
 	MemoryFileSystem.prototype[fn] = function(path, callback) {
 		try {
 			var result = this[fn + "Sync"](path);
@@ -206,6 +206,10 @@ MemoryFileSystem.prototype.normalize = normalize;
 		return callback(null, result);
 	};
 });
+
+MemoryFileSystem.prototype.exists = function(path, callback) {
+	return callback(this.existsSync(path));
+}
 
 MemoryFileSystem.prototype.readFile = function(path, optArg, callback) {
 	if(!callback) {

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -39,15 +39,24 @@ function pathToArray(path) {
 function trueFn() { return true; }
 function falseFn() { return false; }
 
-MemoryFileSystem.prototype.statSync = function(_path) {
+MemoryFileSystem.prototype.meta = function(_path) {
 	var path = pathToArray(_path);
 	var current = this.data;
 	for(var i = 0; i < path.length - 1; i++) {
 		if(!isDir(current[path[i]]))
-			throw new Error("Path doesn't exist '" + _path + "'");
+			return null;
 		current = current[path[i]];
 	}
-	if(_path === "/" || isDir(current[path[i]])) {
+	return current[path[i]];
+}
+
+MemoryFileSystem.prototype.existsSync = function(_path) {
+	return !!this.meta(_path);
+}
+
+MemoryFileSystem.prototype.statSync = function(_path) {
+	var current = this.meta(_path);
+	if(_path === "/" || isDir(current)) {
 		return {
 			isFile: falseFn,
 			isDirectory: trueFn,
@@ -57,7 +66,7 @@ MemoryFileSystem.prototype.statSync = function(_path) {
 			isFIFO: falseFn,
 			isSocket: falseFn
 		};
-	} else if(isFile(current[path[i]])) {
+	} else if(isFile(current)) {
 		return {
 			isFile: trueFn,
 			isDirectory: falseFn,
@@ -187,7 +196,7 @@ MemoryFileSystem.prototype.normalize = normalize;
 
 // async functions
 
-["stat", "readdir", "mkdirp", "mkdir", "rmdir", "unlink", "readlink"].forEach(function(fn) {
+["exists", "stat", "readdir", "mkdirp", "mkdir", "rmdir", "unlink", "readlink"].forEach(function(fn) {
 	MemoryFileSystem.prototype[fn] = function(path, callback) {
 		try {
 			var result = this[fn + "Sync"](path);

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -28,11 +28,13 @@ describe("directory", function() {
 		fs.readdirSync("//test").should.be.eql(["sub2"]);
 		fs.rmdirSync("/test/sub2");
 		fs.rmdirSync("/test");
+		fs.existsSync("/test").should.be.eql(false);
 		(function() {
 			fs.readdirSync("/test");
 		}).should.throw();
 		fs.readdirSync("/").should.be.eql(["root\\dir"]);
 		fs.mkdirpSync("/a/depth/sub/dir");
+		fs.existsSync("/a/depth/sub").should.be.eql(true);
 		var stat = fs.statSync("/a/depth/sub");
 		stat.isFile().should.be.eql(false);
 		stat.isDirectory().should.be.eql(true);
@@ -50,11 +52,13 @@ describe("directory", function() {
 		fs.readdirSync("C:\\\\test").should.be.eql(["sub2"]);
 		fs.rmdirSync("C:\\test\\sub2");
 		fs.rmdirSync("C:\\test");
+		fs.existsSync("C:\\test").should.be.eql(false);
 		(function() {
 			fs.readdirSync("C:\\test");
 		}).should.throw();
 		fs.readdirSync("C:").should.be.eql(["root-dir"]);
 		fs.mkdirpSync("D:\\a\\depth\\sub\\dir");
+		fs.existsSync("D:\\a\\depth\\sub").should.be.eql(true);
 		var stat = fs.statSync("D:\\a\\depth\\sub");
 		stat.isFile().should.be.eql(false);
 		stat.isDirectory().should.be.eql(true);

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -210,7 +210,10 @@ describe("async", function() {
 						fs.readFile("/test/dir/b", function(err, content) {
 							if(err) throw err;
 							content.should.be.eql(new Buffer("World"));
-							done();
+							fs.exists("/test/dir/b", function(exists) {
+								exists.should.be.eql(true);
+								done();
+							});
 						});
 					});
 				});


### PR DESCRIPTION
Sometimes you'd rather prefer not having an error thrown (à la `.stat`). Because both functions share the code for fetching the internal file object, it has been refactored out into a common function called `meta`.

Specs updated to match.