### PR TITLE
Support `createReadStream` and `createWriteStream`.

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -4,7 +4,7 @@
 */
 
 var normalize = require("./normalize");
-var stream = require("stream");
+var stream = require("readable-stream");
 
 var ReadableStream = stream.Readable;
 var WritableStream = stream.Writable;

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -4,6 +4,10 @@
 */
 
 var normalize = require("./normalize");
+var stream = require("stream");
+
+var ReadableStream = stream.Readable;
+var WritableStream = stream.Writable;
 
 function MemoryFileSystem(data) {
 	this.data = data || {};
@@ -184,6 +188,60 @@ MemoryFileSystem.prototype.writeFileSync = function(_path, content, encoding) {
 MemoryFileSystem.prototype.join = require("./join");
 
 MemoryFileSystem.prototype.normalize = normalize;
+
+// stream functions
+
+MemoryFileSystem.prototype.createReadStream = function(path, options) {
+	var stream = new ReadableStream();
+	var done = false;
+	var data;
+	try {
+		data = this.readFileSync(path);
+	} catch (e) {
+		stream._read = function() {
+			if (done) {
+				return;
+			}
+			done = true;
+			this.emit('error', e);
+			this.push(null);
+		};
+		return stream;
+	}
+	options = options || { };
+	options.start = options.start || 0;
+	options.end = options.end || data.length;
+	stream._read = function() {
+		if (done) {
+			return;
+		}
+		done = true;
+		this.push(data.slice(options.start, options.end));
+		this.push(null);
+	};
+	return stream;
+};
+
+MemoryFileSystem.prototype.createWriteStream = function(path, options) {
+	var stream = new WritableStream(), self = this;
+	try {
+		// Zero the file and make sure it is writable
+		this.writeFileSync(path, new Buffer(0));
+	} catch(e) {
+		// This or setImmediate?
+		stream.once('prefinish', function() {
+			stream.emit('error', e);
+		});
+		return stream;
+	}
+	var bl = [ ], len = 0;
+	stream._write = function(chunk, encoding, callback) {
+		bl.push(chunk);
+		len += chunk.length;
+		self.writeFile(path, Buffer.concat(bl, len), callback);
+	}
+	return stream;
+};
 
 // async functions
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/webpack/memory-fs",
   "devDependencies": {
+    "bl": "^1.0.0",
     "istanbul": "^0.2.13",
     "mocha": "^1.20.1",
     "should": "^4.0.4"

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "istanbul": "^0.2.13",
     "mocha": "^1.20.1",
     "should": "^4.0.4"
+  },
+  "dependencies": {
+    "readable-stream": "^2.0.1"
   }
 }


### PR DESCRIPTION
Preliminary support for the functions by the same name from the `fs` module.

See also https://github.com/pillarjs/send/pull/78

You can then roll your own `dev-middleware` implementation with:

```javascript
function middleware(compiler, options) {
	return serveStatic(compiler.options.output.path, {
		fs: compiler.outputFileSystem,
		fallthrough: false
	})
}
```

It makes it equally easy to use for production since you just swap out `fs` to native after and everything carries on as it were.

There will have to be one further PR enhancing the result from `statSync` to make it fully compatible.

/cc @sokra 