### PR TITLE
Use real node errors.

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -4,6 +4,18 @@
 */
 
 var normalize = require("./normalize");
+var errors = require("errno");
+
+function MemoryFileSystemError(err, path) {
+	Error.call(this)
+	if (Error.captureStackTrace)
+		Error.captureStackTrace(this, arguments.callee)
+	this.code = err.code;
+	this.errno = err.errno;
+	this.message = err.description;
+	this.path = path;
+}
+MemoryFileSystemError.prototype = new Error();
 
 function MemoryFileSystem(data) {
 	this.data = data || {};
@@ -24,7 +36,9 @@ function pathToArray(path) {
 	path = normalize(path);
 	var nix = /^\//.test(path);
 	if(!nix) {
-		if(!/^[A-Za-z]:/.test(path)) throw new Error("Invalid path '" + path + "'");
+		if(!/^[A-Za-z]:/.test(path)) {
+			throw new MemoryFileSystemError(errors.code.EINVAL, path);
+		}
 		path = path.replace(/[\\\/]+/g, "\\"); // multi slashs
 		path = path.split(/[\\\/]/);
 		path[0] = path[0].toUpperCase();
@@ -76,8 +90,9 @@ MemoryFileSystem.prototype.statSync = function(_path) {
 			isFIFO: falseFn,
 			isSocket: falseFn
 		};
-	} else
-		throw new Error("Path doesn't exist '" + _path + "'");
+	} else {
+		throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+	}
 };
 
 MemoryFileSystem.prototype.readFileSync = function(_path, encoding) {
@@ -85,14 +100,14 @@ MemoryFileSystem.prototype.readFileSync = function(_path, encoding) {
 	var current = this.data;
 	for(var i = 0; i < path.length - 1; i++) {
 		if(!isDir(current[path[i]]))
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 		current = current[path[i]];
 	}
 	if(!isFile(current[path[i]])) {
 		if(isDir(current[path[i]]))
-			throw new Error("Cannot readFile on directory '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.EISDIR, _path);
 		else
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 	}
 	current = current[path[i]];
 	return encoding ? current.toString(encoding) : current;
@@ -104,14 +119,14 @@ MemoryFileSystem.prototype.readdirSync = function(_path) {
 	var current = this.data;
 	for(var i = 0; i < path.length - 1; i++) {
 		if(!isDir(current[path[i]]))
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 		current = current[path[i]];
 	}
 	if(!isDir(current[path[i]])) {
 		if(isFile(current[path[i]]))
-			throw new Error("Cannot readdir on file '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOTDIR, _path);
 		else
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 	}
 	return Object.keys(current[path[i]]).filter(Boolean);
 };
@@ -122,7 +137,7 @@ MemoryFileSystem.prototype.mkdirpSync = function(_path) {
 	var current = this.data;
 	for(var i = 0; i < path.length; i++) {
 		if(isFile(current[path[i]]))
-			throw new Error("Path is a file '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOTDIR, _path);
 		else if(!isDir(current[path[i]]))
 			current[path[i]] = {"":true};
 		current = current[path[i]];
@@ -136,28 +151,30 @@ MemoryFileSystem.prototype.mkdirSync = function(_path) {
 	var current = this.data;
 	for(var i = 0; i < path.length - 1; i++) {
 		if(!isDir(current[path[i]]))
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 		current = current[path[i]];
 	}
 	if(isDir(current[path[i]]))
-		throw new new Error("Directory already exist '" + _path + "'");
+		throw new MemoryFileSystemError(errors.code.EEXIST, _path);
 	else if(isFile(current[path[i]]))
-		throw new Error("Cannot mkdir on file '" + _path + "'");
+		throw new MemoryFileSystemError(errors.code.ENOTDIR, _path);
 	current[path[i]] = {"":true};
 	return;
 };
 
 MemoryFileSystem.prototype._remove = function(_path, name, testFn) {
 	var path = pathToArray(_path);
-	if(path.length === 0) throw new Error("Path cannot be removed '" + _path + "'");
+	if(path.length === 0) {
+		throw new MemoryFileSystemError(errors.code.EPERM, _path);
+	}
 	var current = this.data;
 	for(var i = 0; i < path.length - 1; i++) {
 		if(!isDir(current[path[i]]))
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 		current = current[path[i]];
 	}
 	if(!testFn(current[path[i]]))
-		throw new Error("'" + name + "' doesn't exist '" + _path + "'");
+		throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 	delete current[path[i]];
 	return;
 };
@@ -171,21 +188,23 @@ MemoryFileSystem.prototype.unlinkSync = function(_path) {
 };
 
 MemoryFileSystem.prototype.readlinkSync = function(_path) {
-	throw new Error("Path is not a link '" + _path + "'");
+	throw new MemoryFileSystemError(errors.code.ENOSYS, _path);
 };
 
 MemoryFileSystem.prototype.writeFileSync = function(_path, content, encoding) {
 	if(!content && !encoding) throw new Error("No content");
 	var path = pathToArray(_path);
-	if(path.length === 0) throw new Error("Path is not a file '" + _path + "'");
+	if(path.length === 0) {
+		throw new MemoryFileSystemError(errors.code.EISDIR, _path);
+	}
 	var current = this.data;
 	for(var i = 0; i < path.length - 1; i++) {
 		if(!isDir(current[path[i]]))
-			throw new Error("Path doesn't exist '" + _path + "'");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 		current = current[path[i]];
 	}
 	if(isDir(current[path[i]]))
-		throw new Error("Cannot writeFile on directory '" + _path + "'");
+		throw new MemoryFileSystemError(errors.code.EISDIR, _path);
 	current[path[i]] = encoding || typeof content === "string" ? new Buffer(content, encoding) : content;
 	return;
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/webpack/memory-fs/issues"
   },
   "homepage": "https://github.com/webpack/memory-fs",
+  "dependencies": {
+    "errno": "^0.1.3"  
+  },
   "devDependencies": {
     "codecov.io": "^0.1.4",
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Seeing as this is is supposed to mimick node's underlying file-system, seems to make sense to use the same errors. Also means that it becomes easier to use this to stub out the `fs` module.