### PR TITLE
Add ability to have relative file paths to unix machines

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -38,7 +38,7 @@ function isFile(item) {
 
 function pathToArray(path) {
 	path = normalize(path);
-	var nix = /^\//.test(path);
+	var nix = /^\.{0,2}\//.test(path);
 	if(!nix) {
 		if(!/^[A-Za-z]:/.test(path)) {
 			throw new MemoryFileSystemError(errors.code.EINVAL, path);


### PR DESCRIPTION
The `nix` matcher would originally match relative paths on unix as windows files paths.
This allows the path to contain 0, 1 or 2 leading dots ('.') and corrects this bug.