### PR TITLE
For async mkdir, call the callback when passed as the third argument

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -273,7 +273,7 @@ MemoryFileSystem.prototype.createWriteStream = function(path, options) {
 
 // async functions
 
-["stat", "readdir", "mkdirp", "mkdir", "rmdir", "unlink", "readlink"].forEach(function(fn) {
+["stat", "readdir", "mkdirp", "rmdir", "unlink", "readlink"].forEach(function(fn) {
 	MemoryFileSystem.prototype[fn] = function(path, callback) {
 		try {
 			var result = this[fn + "Sync"](path);
@@ -284,22 +284,24 @@ MemoryFileSystem.prototype.createWriteStream = function(path, options) {
 	};
 });
 
+["mkdir", "readFile"].forEach(function(fn) {
+	MemoryFileSystem.prototype[fn] = function(path, optArg, callback) {
+		if(!callback) {
+			callback = optArg;
+			optArg = undefined;
+		}
+		try {
+			var result = this[fn + "Sync"](path, optArg);
+		} catch(e) {
+			return callback(e);
+		}
+		return callback(null, result);
+	};
+});
+
 MemoryFileSystem.prototype.exists = function(path, callback) {
 	return callback(this.existsSync(path));
 }
-
-MemoryFileSystem.prototype.readFile = function(path, optArg, callback) {
-	if(!callback) {
-		callback = optArg;
-		optArg = undefined;
-	}
-	try {
-		var result = this.readFileSync(path, optArg);
-	} catch(e) {
-		return callback(e);
-	}
-	return callback(null, result);
-};
 
 MemoryFileSystem.prototype.writeFile = function (path, content, encoding, callback) {
 	if(!callback) {

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -65,6 +65,13 @@ describe("directory", function() {
 		stat.isDirectory().should.be.eql(true);
 		fs.readdirSync("D:\\//a/depth/\\sub").should.be.eql(["dir"]);
 	});
+	it("should call a mkdir callback when passed as the third argument", function(done) {
+		var fs = new MemoryFileSystem();
+		fs.mkdir('/test', {}, function(err) {
+			if (err) throw err;
+			done();
+		});
+	});
 });
 describe("files", function() {
 	it("should make and remove files", function() {


### PR DESCRIPTION
This is for parity with the [Node.js fs.mkdir implementation](https://nodejs.org/dist/latest-v5.x/docs/api/fs.html#fs_fs_mkdir_path_mode_callback), which may optionally accept options as the 2nd argument.

Previously, using memory-fs along with [mkdirp](https://github.com/substack/node-mkdirp) results in this error:
```js
var fs = new MemoryFileSystem();
mkdirp('/some/dir', { fs: fs }, cb => {/*...*/})
```
```
TypeError: callback is not a function
    at MemoryFileSystem.(anonymous function) [as mkdir] (node_modules/memory-fs/lib/MemoryFileSystem.js:281:11)
    at mkdirP (node_modules/mkdirp/index.js:27:9)
```

This PR will resolve such errors.