### PR TITLE
fix: handle "./.." case

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -25,9 +25,14 @@ module.exports = function normalize(path) {
 					// i. e. "a/../b/c" => "b/c"
 					// i. e. "/../b/c" => "/b/c"
 					// i. e. "C:\..\a\b\c" => "C:\a\b\c"
-					i++;
-					sep = !sep;
-					result.length = absolutePathStart;
+					if (result[0] !== ".") {
+						i++;
+						sep = !sep;
+						result.length = absolutePathStart;
+					} else {
+						result.length = 0;
+						result.push(part);
+					}
 					break;
 				case 4:
 					// i. e. "a/b/.." => "a"
@@ -80,7 +85,7 @@ module.exports = function normalize(path) {
 			result.push(part);
 		}
 	}
-	if(result.length === 1 && /^[A-Za-z]:$/.test(result))
+	if(result.length === 1 && /^[A-Za-z]:$/.test(result[0]))
 		return result[0] + "\\";
 	return result.join("");
 };

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -355,6 +355,11 @@ describe("normalize", function() {
 		fs.normalize("C:\\a\\b\\\c\\..\\..").should.be.eql("C:\\a");
 		fs.normalize("C:\\a\\b\\d\\..\\c\\..\\..").should.be.eql("C:\\a");
 		fs.normalize("C:\\a\\b\\d\\\\.\\\\.\\c\\.\\..").should.be.eql("C:\\a\\b\\d");
+		fs.normalize("./../a").should.be.eql("../a");
+		fs.normalize("/a/./../b").should.be.eql("/b");
+		fs.normalize("/./../b").should.be.eql("/b");
+		fs.normalize("C:\\.\\..\\a").should.be.eql("C:\\a");
+		fs.normalize("C:\\a\\.\\..\\b").should.be.eql("C:\\b");
 	});
 });
 describe("pathToArray", function() {


### PR DESCRIPTION
Previously, "./../a" was incorrectly transformed to "a".  Paths of
that form are sometimes seen by the webpack AliasPlugin.