### PR TITLE
Normalize UNC paths correctly.

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -10,7 +10,12 @@ module.exports = function normalize(path) {
 			result.push(part);
 			absolutePathStart = 2;
 		} else if(sep) {
-			result.push(part[0]);
+			// UNC paths on Windows begin with a double backslash.
+			if (i === 1 && parts[0].length === 0 && part === "\\\\") {
+				result.push(part);
+			} else {
+				result.push(part[0]);
+			}
 		} else if(part === "..") {
 			switch(result.length) {
 				case 0:

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -355,6 +355,7 @@ describe("normalize", function() {
 		fs.normalize("C:\\a\\b\\\c\\..\\..").should.be.eql("C:\\a");
 		fs.normalize("C:\\a\\b\\d\\..\\c\\..\\..").should.be.eql("C:\\a");
 		fs.normalize("C:\\a\\b\\d\\\\.\\\\.\\c\\.\\..").should.be.eql("C:\\a\\b\\d");
+		fs.normalize("\\\\remote-computer\\c$\\file").should.be.eql("\\\\remote-computer\\c$\\file");
 	});
 });
 describe("pathToArray", function() {


### PR DESCRIPTION
On Windows, paths to network shares begin with a `\\` (for example, `\\remote-computer\sharedFolder\file`), and these paths are inappropriately reduced to beginning with a single backslash by `memory-fs`'s `normalize` function.

This PR fixes that.