### PR TITLE
fix: allow encoding to come from options

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -106,7 +106,7 @@ class MemoryFileSystem {
 		}
 	}
 
-	readFileSync(_path, encoding) {
+	readFileSync(_path, optionsOrEncoding) {
 		const path = pathToArray(_path);
 		let current = this.data;
 		let i = 0
@@ -122,6 +122,7 @@ class MemoryFileSystem {
 				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
 		}
 		current = current[path[i]];
+		const encoding = typeof optionsOrEncoding === "object" ? optionsOrEncoding.encoding : optionsOrEncoding;
 		return encoding ? current.toString(encoding) : current;
 	}
 
@@ -206,8 +207,8 @@ class MemoryFileSystem {
 		throw new MemoryFileSystemError(errors.code.ENOSYS, _path);
 	}
 
-	writeFileSync(_path, content, encoding) {
-		if(!content && !encoding) throw new Error("No content");
+	writeFileSync(_path, content, optionsOrEncoding) {
+		if(!content && !optionsOrEncoding) throw new Error("No content");
 		const path = pathToArray(_path);
 		if(path.length === 0) {
 			throw new MemoryFileSystemError(errors.code.EISDIR, _path);
@@ -221,7 +222,8 @@ class MemoryFileSystem {
 		}
 		if(isDir(current[path[i]]))
 			throw new MemoryFileSystemError(errors.code.EISDIR, _path);
-		current[path[i]] = encoding || typeof content === "string" ? new Buffer(content, encoding) : content;
+		const encoding = typeof optionsOrEncoding === "object" ? optionsOrEncoding.encoding : optionsOrEncoding;
+		current[path[i]] = optionsOrEncoding || typeof content === "string" ? new Buffer(content, encoding) : content;
 		return;
 	}
 

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -81,6 +81,7 @@ describe("files", function() {
 		fs.writeFileSync("/test/hello-world.txt", buf);
 		fs.readFileSync("/test/hello-world.txt").should.be.eql(buf);
 		fs.readFileSync("/test/hello-world.txt", "utf-8").should.be.eql("Hello World");
+		fs.readFileSync("/test/hello-world.txt", {encoding: "utf-8"}).should.be.eql("Hello World");
 		(function() {
 			fs.readFileSync("/test/other-file");
 		}).should.throw();
@@ -92,6 +93,8 @@ describe("files", function() {
 		var stat = fs.statSync("/a");
 		stat.isFile().should.be.eql(true);
 		stat.isDirectory().should.be.eql(false);
+		fs.writeFileSync("/b", "Test", {encoding: "utf-8"});
+		fs.readFileSync("/b", "utf-8").should.be.eql("Test");
 	});
 });
 describe("errors", function() {


### PR DESCRIPTION
Per docs:
- https://nodejs.org/api/fs.html#fs_fs_writefilesync_file_data_options
- https://nodejs.org/api/fs.html#fs_fs_readfilesync_file_options