### PR TITLE
Prettify Error message and stack display, fix #32 .

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -202,6 +202,7 @@
             "error",
             "always"
         ],
+        "strict": "error",
         "symbol-description": "error",
         "template-curly-spacing": "error",
         "unicode-bom": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
 		"es6": true
     },
     "parserOptions": {
-        "sourceType": "module"
+        "sourceType": "script"
     },
     "rules": {
         "accessor-pairs": "error",
@@ -74,10 +74,6 @@
         "id-blacklist": "error",
         "id-match": "error",
         "jsx-quotes": "error",
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
         "lines-around-comment": "error",
         "lines-around-directive": "error",
         "max-depth": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -202,7 +202,6 @@
             "error",
             "always"
         ],
-        "strict": "error",
         "symbol-description": "error",
         "template-curly-spacing": "error",
         "unicode-bom": [

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
-  - "7"
+  - "8"
 script: npm run travis
 
 before_install:

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+
 "use strict";
 
 const normalize = require("./normalize");

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -168,18 +168,19 @@ class MemoryFileSystem {
 
 	_remove(_path, name, testFn) {
 		const path = pathToArray(_path);
+		const operation = name === "File" ? "unlink" : "rmdir";
 		if(path.length === 0) {
-			throw new MemoryFileSystemError(errors.code.EPERM, _path, "remove");
+			throw new MemoryFileSystemError(errors.code.EPERM, _path, operation);
 		}
 		let current = this.data;
 		let i = 0;
 		for(; i < path.length - 1; i++) {
 			if(!isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "remove");
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, operation);
 			current = current[path[i]];
 		}
 		if(!testFn(current[path[i]]))
-			throw new MemoryFileSystemError(errors.code.ENOENT, _path, "remove");
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path, operation);
 		delete current[path[i]];
 		return;
 	}

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -91,7 +91,7 @@ class MemoryFileSystem {
 				isSocket: falseFn
 			};
 		} else {
-			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path, "stat");
 		}
 	}
 
@@ -101,14 +101,14 @@ class MemoryFileSystem {
 		let i = 0
 		for(; i < path.length - 1; i++) {
 			if(!isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "readFile");
 			current = current[path[i]];
 		}
 		if(!isFile(current[path[i]])) {
 			if(isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.EISDIR, _path);
+				throw new MemoryFileSystemError(errors.code.EISDIR, _path, "readFile");
 			else
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "readFile");
 		}
 		current = current[path[i]];
 		return encoding ? current.toString(encoding) : current;
@@ -121,14 +121,14 @@ class MemoryFileSystem {
 		let i = 0;
 		for(; i < path.length - 1; i++) {
 			if(!isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "readdir");
 			current = current[path[i]];
 		}
 		if(!isDir(current[path[i]])) {
 			if(isFile(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOTDIR, _path);
+				throw new MemoryFileSystemError(errors.code.ENOTDIR, _path, "readdir");
 			else
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "readdir");
 		}
 		return Object.keys(current[path[i]]).filter(Boolean);
 	}
@@ -139,7 +139,7 @@ class MemoryFileSystem {
 		let current = this.data;
 		for(let i = 0; i < path.length; i++) {
 			if(isFile(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOTDIR, _path);
+				throw new MemoryFileSystemError(errors.code.ENOTDIR, _path, "mkdirp");
 			else if(!isDir(current[path[i]]))
 				current[path[i]] = {"":true};
 			current = current[path[i]];
@@ -154,13 +154,13 @@ class MemoryFileSystem {
 		let i = 0;
 		for(; i < path.length - 1; i++) {
 			if(!isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "mkdir");
 			current = current[path[i]];
 		}
 		if(isDir(current[path[i]]))
-			throw new MemoryFileSystemError(errors.code.EEXIST, _path);
+			throw new MemoryFileSystemError(errors.code.EEXIST, _path, "mkdir");
 		else if(isFile(current[path[i]]))
-			throw new MemoryFileSystemError(errors.code.ENOTDIR, _path);
+			throw new MemoryFileSystemError(errors.code.ENOTDIR, _path, "mkdir");
 		current[path[i]] = {"":true};
 		return;
 	}
@@ -168,17 +168,17 @@ class MemoryFileSystem {
 	_remove(_path, name, testFn) {
 		const path = pathToArray(_path);
 		if(path.length === 0) {
-			throw new MemoryFileSystemError(errors.code.EPERM, _path);
+			throw new MemoryFileSystemError(errors.code.EPERM, _path, "remove");
 		}
 		let current = this.data;
 		let i = 0;
 		for(; i < path.length - 1; i++) {
 			if(!isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "remove");
 			current = current[path[i]];
 		}
 		if(!testFn(current[path[i]]))
-			throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+			throw new MemoryFileSystemError(errors.code.ENOENT, _path, "remove");
 		delete current[path[i]];
 		return;
 	}
@@ -192,24 +192,24 @@ class MemoryFileSystem {
 	}
 
 	readlinkSync(_path) {
-		throw new MemoryFileSystemError(errors.code.ENOSYS, _path);
+		throw new MemoryFileSystemError(errors.code.ENOSYS, _path, "readlink");
 	}
 
 	writeFileSync(_path, content, encoding) {
 		if(!content && !encoding) throw new Error("No content");
 		const path = pathToArray(_path);
 		if(path.length === 0) {
-			throw new MemoryFileSystemError(errors.code.EISDIR, _path);
+			throw new MemoryFileSystemError(errors.code.EISDIR, _path, "writeFile");
 		}
 		let current = this.data;
 		let i = 0
 		for(; i < path.length - 1; i++) {
 			if(!isDir(current[path[i]]))
-				throw new MemoryFileSystemError(errors.code.ENOENT, _path);
+				throw new MemoryFileSystemError(errors.code.ENOENT, _path, "writeFile");
 			current = current[path[i]];
 		}
 		if(isDir(current[path[i]]))
-			throw new MemoryFileSystemError(errors.code.EISDIR, _path);
+			throw new MemoryFileSystemError(errors.code.EISDIR, _path, "writeFile");
 		current[path[i]] = encoding || typeof content === "string" ? new Buffer(content, encoding) : content;
 		return;
 	}

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -6,23 +6,12 @@
 
 const normalize = require("./normalize");
 const join = require("./join");
+const MemoryFileSystemError = require("./MemoryFileSystemError");
 const errors = require("errno");
 const stream = require("readable-stream");
 
 const ReadableStream = stream.Readable;
 const WritableStream = stream.Writable;
-
-class MemoryFileSystemError extends Error {
-	constructor(err, path) {
-		super(err, path);
-		if (Error.captureStackTrace)
-			Error.captureStackTrace(this, this.constructor)
-		this.code = err.code;
-		this.errno = err.errno;
-		this.message = err.description;
-		this.path = path;
-	}
-}
 
 function isDir(item) {
 	if(typeof item !== "object") return false;

--- a/lib/MemoryFileSystemError.js
+++ b/lib/MemoryFileSystemError.js
@@ -1,0 +1,47 @@
+const operationMatchReg = new RegExp("at\\sMemoryFileSystem\\.([^\\s_]+)\\s");
+
+class MemoryFileSystemError extends Error {
+	constructor(err, path) {
+		super(err, path);
+
+		// Set `name` and `message` before call `Error.captureStackTrace` \
+		// so that we will obtain the correct 1st line of stack, like:
+		// [Error]: [Message]
+		this.name = this.constructor.name;
+		this.message = `${err.code}: ${err.description}`;
+
+		// Add operation name into error message, similar to node `fs` style.
+		// It will not exactly same as node `fs`'s result which comes from \
+		// the native call (like `readFile` => `binding.open` => `open`),
+		// but just find out the last method call from the stack.
+		var operation = this.findOperation();
+		if(operation && path) {
+			this.message += `, ${operation} \'${path}\'`;
+		} else if(path) {
+			this.message += `, \'${path}\'`;
+		}
+		this.code = err.code;
+		this.errno = err.errno;
+		this.path = path;
+
+		if(Error.captureStackTrace) {
+			Error.captureStackTrace(this, this.constructor);
+		}
+	}
+	findOperation() {
+		if(!this.stack) return null;
+		var stacks = this.stack.split(/[\r\n|\n][\s]*/), findDepth = 1, operation;
+		while(!operation && findDepth < stacks.length) {
+			var stack = stacks[findDepth];
+			var operationMatch = stack.match(operationMatchReg);
+			if(operationMatch) {
+				operation = operationMatch[1];
+			}
+			findDepth += 1;
+		}
+
+		return operation || null;
+	}
+}
+
+module.exports = MemoryFileSystemError;

--- a/lib/MemoryFileSystemError.js
+++ b/lib/MemoryFileSystemError.js
@@ -1,57 +1,30 @@
 
 "use strict";
 
-const operationMatchReg = new RegExp("at\\sMemoryFileSystem\\.([^\\s_]+)\\s");
-
 class MemoryFileSystemError extends Error {
-	constructor(err, path) {
+	constructor(err, path, operation) {
 		super(err, path);
 
 		// Set `name` and `message` before call `Error.captureStackTrace` \
 		// so that we will obtain the correct 1st line of stack, like:
 		// [Error]: [Message]
 		this.name = this.constructor.name;
-		this.message = `${err.code}: ${err.description}`;
-
-		// Add operation name into error message, similar to node `fs` style.
-		// It will not exactly same as node `fs`'s result which comes from \
-		// the native call (like `readFile` => `binding.open` => `open`),
-		// but just find out the last method call from the stack.
-		var operation = this.findOperation();
-		if(operation && path) {
-			this.message += `, ${operation} \'${path}\'`;
-		} else if(path) {
-			this.message += `, \'${path}\'`;
+		var message = [`${err.code}:`, `${err.description},`];
+		// Add operation name and path into message, similar to node `fs` style.
+		if(operation){
+			message.push(operation);
 		}
+		message.push(`\'${path}\'`);
+		this.message = message.join(' ');
+
 		this.code = err.code;
 		this.errno = err.errno;
 		this.path = path;
+		this.operation = operation;
 
 		if(Error.captureStackTrace) {
 			Error.captureStackTrace(this, this.constructor);
 		}
-	}
-	findOperation() {
-		// use a new obj to capture and inspect stack, because the message \
-		// isn't ready yet, shouldn't invoke stack getter at this time.
-		var captureObj = {};
-		if(Error.captureStackTrace) {
-			Error.captureStackTrace(captureObj);
-		}
-		if(!captureObj.stack) return null;
-		var stacks = captureObj.stack.split(/[\r\n|\n][\s]*/);
-		var findDepth = 1;
-		var operation;
-		while(!operation && findDepth < stacks.length) {
-			var stack = stacks[findDepth];
-			var operationMatch = stack.match(operationMatchReg);
-			if(operationMatch) {
-				operation = operationMatch[1];
-			}
-			findDepth += 1;
-		}
-
-		return operation;
 	}
 }
 

--- a/lib/MemoryFileSystemError.js
+++ b/lib/MemoryFileSystemError.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const operationMatchReg = new RegExp("at\\sMemoryFileSystem\\.([^\\s_]+)\\s");
 
 class MemoryFileSystemError extends Error {
@@ -29,10 +31,16 @@ class MemoryFileSystemError extends Error {
 		}
 	}
 	findOperation() {
-		if(!this.stack) return null;
-		var stacks = this.stack.split(/[\r\n|\n][\s]*/);
-		var operation;
+		// use a new obj to capture and inspect stack, because the message \
+		// isn't ready yet, shouldn't invoke stack getter at this time.
+		var captureObj = {};
+		if(Error.captureStackTrace) {
+			Error.captureStackTrace(captureObj);
+		}
+		if(!captureObj.stack) return null;
+		var stacks = captureObj.stack.split(/[\r\n|\n][\s]*/);
 		var findDepth = 1;
+		var operation;
 		while(!operation && findDepth < stacks.length) {
 			var stack = stacks[findDepth];
 			var operationMatch = stack.match(operationMatchReg);
@@ -42,7 +50,7 @@ class MemoryFileSystemError extends Error {
 			findDepth += 1;
 		}
 
-		return operation || null;
+		return operation;
 	}
 }
 

--- a/lib/MemoryFileSystemError.js
+++ b/lib/MemoryFileSystemError.js
@@ -30,7 +30,9 @@ class MemoryFileSystemError extends Error {
 	}
 	findOperation() {
 		if(!this.stack) return null;
-		var stacks = this.stack.split(/[\r\n|\n][\s]*/), findDepth = 1, operation;
+		var stacks = this.stack.split(/[\r\n|\n][\s]*/);
+		var operation;
+		var findDepth = 1;
 		while(!operation && findDepth < stacks.length) {
 			var stack = stacks[findDepth];
 			var operationMatch = stack.match(operationMatchReg);

--- a/lib/MemoryFileSystemError.js
+++ b/lib/MemoryFileSystemError.js
@@ -1,3 +1,4 @@
+
 "use strict";
 
 const operationMatchReg = new RegExp("at\\sMemoryFileSystem\\.([^\\s_]+)\\s");

--- a/lib/MemoryFileSystemError.js
+++ b/lib/MemoryFileSystemError.js
@@ -11,7 +11,7 @@ class MemoryFileSystemError extends Error {
 		this.name = this.constructor.name;
 		var message = [`${err.code}:`, `${err.description},`];
 		// Add operation name and path into message, similar to node `fs` style.
-		if(operation){
+		if(operation) {
 			message.push(operation);
 		}
 		message.push(`\'${path}\'`);

--- a/lib/join.js
+++ b/lib/join.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const normalize = require("./normalize");
 
 const absoluteWinRegExp = /^[A-Z]:([\\\/]|$)/i;

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,10 +1,12 @@
+"use strict";
+
 module.exports = function normalize(path) {
 	var parts = path.split(/(\\+|\/+)/);
 	if(parts.length === 1)
 		return path;
 	var result = [];
 	var absolutePathStart = 0;
-	for(var i = 0, sep = false; i < parts.length; i++, sep = !sep) {
+	for(var i = 0, sep = false; i < parts.length; i += 1, sep = !sep) {
 		var part = parts[i];
 		if(i === 0 && /^([A-Z]:)?$/i.test(part)) {
 			result.push(part);
@@ -30,7 +32,7 @@ module.exports = function normalize(path) {
 					// i. e. "a/../b/c" => "b/c"
 					// i. e. "/../b/c" => "/b/c"
 					// i. e. "C:\..\a\b\c" => "C:\a\b\c"
-					i++;
+					i += 1;
 					sep = !sep;
 					result.length = absolutePathStart;
 					break;
@@ -42,7 +44,7 @@ module.exports = function normalize(path) {
 					if(absolutePathStart === 0) {
 						result.length -= 3;
 					} else {
-						i++;
+						i += 1;
 						sep = !sep;
 						result.length = 2;
 					}
@@ -66,9 +68,9 @@ module.exports = function normalize(path) {
 					// i. e. "C:\." => "C:\"
 					// i. e. "C:\.\a\b\c" => "C:\a\b\c"
 					if(absolutePathStart === 0) {
-						result.length--;
+						result.length -= 1;
 					} else {
-						i++;
+						i += 1;
 						sep = !sep;
 					}
 					break;
@@ -78,7 +80,7 @@ module.exports = function normalize(path) {
 					// i. e. "C:\a\." => "C:\"
 					// i. e. "a/./b/c" => "a/b/c"
 					// i. e. "/a/./b/c" => "/a/b/c"
-					result.length--;
+					result.length -= 1;
 					break;
 			}
 		} else if(part) {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   ],
   "scripts": {
     "test": "mocha",
+    "lint": "eslint lib/*",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha",
-    "travis": "npm run cover -- --report lcovonly"
+    "travis": "npm run cover -- --report lcovonly && npm run lint"
   },
   "engines": {
     "node": ">=4.3.0 <5.0.0 || >=5.10"
@@ -35,6 +36,7 @@
     "bl": "^1.0.0",
     "codecov.io": "^0.1.4",
     "coveralls": "^2.11.2",
+    "eslint": "^4.0.0",
     "istanbul": "0.4.5",
     "mocha": "3.2.0",
     "should": "^4.0.4"

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -95,15 +95,6 @@ describe("files", function() {
 	});
 });
 describe("errors", function() {
-	function catchError(fn) {
-		try {
-			fn();
-		} catch(e) {
-			return e;
-		}
-		return null;
-	}
-
 	it("should fail on invalid paths", function() {
 		var fs = new MemoryFileSystem();
 		fs.mkdirpSync("/test/a/b/c");
@@ -150,30 +141,6 @@ describe("errors", function() {
 		}).should.throw();
 		fs.mkdir("/test/a/d/b/c", function(err) {
 			err.should.be.instanceof(Error);
-		});
-	});
-	it("should include the path in Error message", function(done) {
-		var fs = new MemoryFileSystem();
-		var invalidPath = "/nonexist/file";
-		var error = catchError(function() {
-			fs.statSync(invalidPath);
-		});
-		error.message.indexOf(invalidPath).should.be.above(-1);
-
-		fs.readFile(invalidPath, function(err) {
-			err.message.indexOf(invalidPath).should.be.above(-1);
-			done();
-		});
-	});
-	it("should use correct error name and message in the first line of Error stack", function(done) {
-		var fs = new MemoryFileSystem();
-		fs.unlink("/test/abcd", function(error) {
-			error.should.be.instanceof(Error);
-			var firstLine = error.stack.split(/\r\n|\n/)[0];
-			firstLine.should.startWith(error.name);
-			firstLine.indexOf(error.code).should.be.above(-1);
-			firstLine.indexOf(error.message).should.be.above(-1);
-			done();
 		});
 	});
 	it("should fail incorrect arguments", function() {

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -95,14 +95,14 @@ describe("files", function() {
 	});
 });
 describe("errors", function() {
-	var catchError = function(fn) {
+	function catchError(fn) {
 		try {
 			fn();
 		} catch(e) {
 			return e;
 		}
 		return null;
-	};
+	}
 
 	it("should fail on invalid paths", function() {
 		var fs = new MemoryFileSystem();

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -95,6 +95,15 @@ describe("files", function() {
 	});
 });
 describe("errors", function() {
+	var catchError = function(fn) {
+		try {
+			fn();
+		} catch(e) {
+			return e;
+		}
+		return null;
+	};
+
 	it("should fail on invalid paths", function() {
 		var fs = new MemoryFileSystem();
 		fs.mkdirpSync("/test/a/b/c");
@@ -141,6 +150,30 @@ describe("errors", function() {
 		}).should.throw();
 		fs.mkdir("/test/a/d/b/c", function(err) {
 			err.should.be.instanceof(Error);
+		});
+	});
+	it("should include the path in Error message", function(done) {
+		var fs = new MemoryFileSystem();
+		var invalidPath = "/nonexist/file";
+		var error = catchError(function() {
+			fs.statSync(invalidPath);
+		});
+		error.message.indexOf(invalidPath).should.be.above(-1);
+
+		fs.readFile(invalidPath, function(err) {
+			err.message.indexOf(invalidPath).should.be.above(-1);
+			done();
+		});
+	});
+	it("should use correct error name and message in the first line of Error stack", function(done) {
+		var fs = new MemoryFileSystem();
+		fs.unlink("/test/abcd", function(error) {
+			error.should.be.instanceof(Error);
+			var firstLine = error.stack.split(/\r\n|\n/)[0];
+			firstLine.should.startWith(error.name);
+			firstLine.indexOf(error.code).should.be.above(-1);
+			firstLine.indexOf(error.message).should.be.above(-1);
+			done();
 		});
 	});
 	it("should fail incorrect arguments", function() {

--- a/test/MemoryFileSystemError.js
+++ b/test/MemoryFileSystemError.js
@@ -1,0 +1,51 @@
+var bl = require("bl");
+var should = require("should");
+var MemoryFileSystem = require("../lib/MemoryFileSystem");
+var MemoryFileSystemError = require("../lib/MemoryFileSystemError");
+
+describe("error", function() {
+	function catchError(fn) {
+		try {
+			fn();
+		} catch(e) {
+			return e;
+		}
+		return null;
+	}
+
+	it("should include the path in Error message", function(done) {
+		var fs = new MemoryFileSystem();
+		var invalidPath = "/nonexist/file";
+		var error = catchError(function() {
+			fs.statSync(invalidPath);
+		});
+		error.message.should.containEql(invalidPath);
+
+		fs.readFile(invalidPath, function(err) {
+			err.message.should.containEql(invalidPath);
+			done();
+		});
+	});
+	it("should use correct error message in the first line of Error stack", function(done) {
+		var fs = new MemoryFileSystem();
+		fs.unlink("/test/abcd", function(error) {
+			error.should.be.instanceof(Error);
+			error.stack.should.startWith(error.name);
+
+			var firstLine = error.stack.split(/\r\n|\n/)[0];
+			firstLine.should.containEql(error.code);
+			firstLine.should.containEql(error.message);
+			done();
+		});
+	});
+	it("should work fine without path and operation", function() {
+		var errorData = {
+			code:"ETEST",
+			description:"testerror",
+		};
+		var error = new MemoryFileSystemError(errorData);
+		error.message.should.startWith(error.code);
+		error.stack.should.startWith(error.name);
+		error.stack.should.containEql(error.message);
+	});
+});

--- a/test/MemoryFileSystemError.js
+++ b/test/MemoryFileSystemError.js
@@ -41,7 +41,7 @@ describe("error", function() {
 	it("should work fine without path and operation", function() {
 		var errorData = {
 			code:"ETEST",
-			description:"testerror",
+			description:"testerror"
 		};
 		var error = new MemoryFileSystemError(errorData);
 		error.message.should.startWith(error.code);

--- a/test/MemoryFileSystemError.js
+++ b/test/MemoryFileSystemError.js
@@ -35,17 +35,20 @@ describe("error", function() {
 			var firstLine = error.stack.split(/\r\n|\n/)[0];
 			firstLine.should.containEql(error.code);
 			firstLine.should.containEql(error.message);
+			firstLine.should.containEql(error.operation);
 			done();
 		});
 	});
-	it("should work fine without path and operation", function() {
+	it("should work fine without operation name", function() {
 		var errorData = {
 			code:"ETEST",
 			description:"testerror"
 		};
-		var error = new MemoryFileSystemError(errorData);
+		var errorPath = "file";
+		var error = new MemoryFileSystemError(errorData, errorPath);
 		error.message.should.startWith(error.code);
 		error.stack.should.startWith(error.name);
 		error.stack.should.containEql(error.message);
+		error.stack.should.containEql(errorPath);
 	});
 });


### PR DESCRIPTION
### 1. Add path and operation name into error message, make it easier to figure out.

before (`error.message`):
```
no such file or directory
illegal operation on a directory
operation not permitted
file already exists
not a directory
```

after:
```
ENOENT: no such file or directory, unlinkSync '/test/abcd'
EISDIR: illegal operation on a directory, writeFileSync '/test/dir'
EPERM: operation not permitted, rmdirSync '/'
EEXIST: file already exists, mkdirSync '/test/dir'
ENOTDIR: not a directory, mkdirSync '/test/file'
```

### 2. Change first line of stack to use correct message, instance of [object Object].

before (beginning of `error.stack`):
```
Error: [object Object]
    at MemoryFileSystem.readFileSync (...
```

after:
```
MemoryFileSystemError: ENOENT: no such file or directory, readFileSync '/fail/file'
    at MemoryFileSystem.readFileSync ( ...
```

It will fix #32 .