### PR TITLE
Fix join paths in windows

### DIFF
--- a/lib/join.js
+++ b/lib/join.js
@@ -8,9 +8,9 @@ const absoluteNixRegExp = /^\//i;
 module.exports = function join(path, request) {
 	if(!request) return normalize(path);
 	if(absoluteWinRegExp.test(request)) return normalize(request.replace(/\//g, "\\"));
+	if(absoluteWinRegExp.test(path)) return normalize(path.replace(/\//g, "\\") + "\\" + request.replace(/\//g, "\\"));
 	if(absoluteNixRegExp.test(request)) return normalize(request);
 	if(path == "/") return normalize(path + request);
-	if(absoluteWinRegExp.test(path)) return normalize(path.replace(/\//g, "\\") + "\\" + request.replace(/\//g, "\\"));
 	if(absoluteNixRegExp.test(path)) return normalize(path + "/" + request);
 	return normalize(path + "/" + request);
 };


### PR DESCRIPTION
when joining path with "D:\" and "js/app.js", it works fine and output "D:\js\app.js", but when it comes to "D:\" and "/js/app.js", the output becomes "/js/app.js" as absoluteNixRegExp took place before all absoluteWinRegExp is tested.