### PR TITLE
Enable overridable memory-fs errors.

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -53,10 +53,10 @@ class MemoryFileSystem {
 		this.normalize = normalize;
 	}
 
-	meta(_path) {
+	meta(_path, testFn) {
 		const path = pathToArray(_path);
 		if (path === null) {
-			return this.throwError('meta', [_path], [errors.code.EINVAL, _path, "meta"]);
+			return this.throwError(testFn, [_path], [errors.code.EINVAL, _path, testFn]);
 		}
 		let current = this.data;
 		let i = 0;
@@ -69,11 +69,11 @@ class MemoryFileSystem {
 	}
 
 	existsSync(_path) {
-		return !!this.meta(_path);
+		return !!this.meta(_path, 'existsSync');
 	}
 
 	statSync(_path) {
-		let current = this.meta(_path);
+		let current = this.meta(_path, 'statSync');
 		if(_path === "/" || isDir(current)) {
 			return {
 				isFile: falseFn,
@@ -102,7 +102,7 @@ class MemoryFileSystem {
 	readFileSync(_path, optionsOrEncoding) {
 		const path = pathToArray(_path);
 		if (path === null) {
-			return this.throwError('readFileSync', [_path, optionsOrEncoding], [errors.code.EINVAL, _path, "meta"]);
+			return this.throwError('readFileSync', [_path, optionsOrEncoding], [errors.code.EINVAL, _path, "readFile"]);
 		}
 		let current = this.data;
 		let i = 0
@@ -126,7 +126,7 @@ class MemoryFileSystem {
 		if(_path === "/") return Object.keys(this.data).filter(Boolean);
 		const path = pathToArray(_path);
 		if (path === null) {
-			return this.throwError('readdirSync', [_path], [errors.code.EINVAL, _path, "meta"]);
+			return this.throwError('readdirSync', [_path], [errors.code.EINVAL, _path, "readdir"]);
 		}
 		let current = this.data;
 		let i = 0;

--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -306,7 +306,7 @@ class MemoryFileSystem {
 	}
 
 	throwError(fn, args, error) {
-		throw new MemoryFileSystemError(...error);
+		throw new MemoryFileSystemError(error[0], error[1], error[2]);
 	}
 }
 

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -142,6 +142,30 @@ describe("errors", function() {
 		(function() {
 			fs.statSync("/test/abcd");
 		}).should.throw();
+		(function() {
+			fs.existsSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.statSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.readFileSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.readdirSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.mkdirSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.mkdirpSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.rmdirSync("0:/");
+		}).should.throw();
+		(function() {
+			fs.writeFileSync("0:/", 'testing');
+		}).should.throw();
 		fs.mkdir("/test/a/d/b/c", function(err) {
 			err.should.be.instanceof(Error);
 		});


### PR DESCRIPTION
As discussed in issue #46 I've put together a PR to allow consumers to override the default error behavior of memory-fs.

My use case for this change is that if a file is not found in memory-fs, the error behavior can fall back to search for the file in the standard file system.

Now with update tests, and no rest operator.