### PR TITLE
eslint fixes

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,5 +1,7 @@
 "use strict";
 
+/* eslint-disable complexity */
+
 module.exports = function normalize(path) {
 	var parts = path.split(/(\\+|\/+)/);
 	if(parts.length === 1)

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var bl = require("bl");
 var should = require("should");
 var MemoryFileSystem = require("../lib/MemoryFileSystem");

--- a/test/MemoryFileSystemError.js
+++ b/test/MemoryFileSystemError.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var bl = require("bl");
 var should = require("should");
 var MemoryFileSystem = require("../lib/MemoryFileSystem");


### PR DESCRIPTION
eslint was generating a lot of errors because ```"use strict"``` wasn't present in ```test/MemoryFileSystem.js``` and ```test/MemoryFileSystemError.js```