### PR TITLE
Allow writefile to be called with empty string

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -199,7 +199,6 @@ class MemoryFileSystem {
 	}
 
 	writeFileSync(_path, content, optionsOrEncoding) {
-		if(!content && !optionsOrEncoding) throw new Error("No content");
 		const path = pathToArray(_path);
 		if(path.length === 0) {
 			throw new MemoryFileSystemError(errors.code.EISDIR, _path, "writeFile");
@@ -214,7 +213,7 @@ class MemoryFileSystem {
 		if(isDir(current[path[i]]))
 			throw new MemoryFileSystemError(errors.code.EISDIR, _path, "writeFile");
 		const encoding = typeof optionsOrEncoding === "object" ? optionsOrEncoding.encoding : optionsOrEncoding;
-		current[path[i]] = optionsOrEncoding || typeof content === "string" ? new Buffer(content, encoding) : content;
+		current[path[i]] = Buffer.isBuffer(content) ? content : new Buffer(String(content), encoding);
 		return;
 	}
 

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -96,6 +96,15 @@ describe("files", function() {
 		fs.writeFileSync("/b", "Test", {encoding: "utf-8"});
 		fs.readFileSync("/b", "utf-8").should.be.eql("Test");
 	});
+	it("should allow creating empty files", function() {
+		var fs = new MemoryFileSystem();
+		fs.writeFileSync("/empty-buffer", new Buffer(""));
+		fs.readFileSync("/empty-buffer", "utf-8").should.be.eql("");
+		fs.writeFileSync("/empty-string", "");
+		fs.readFileSync("/empty-string", "utf-8").should.be.eql("");
+		fs.writeFileSync("/no-args");
+		fs.readFileSync("/no-args", "utf-8").should.be.eql("undefined");
+	});
 });
 describe("errors", function() {
 	it("should fail on invalid paths", function() {
@@ -145,12 +154,6 @@ describe("errors", function() {
 		fs.mkdir("/test/a/d/b/c", function(err) {
 			err.should.be.instanceof(Error);
 		});
-	});
-	it("should fail incorrect arguments", function() {
-		var fs = new MemoryFileSystem();
-		(function() {
-			fs.writeFileSync("/test");
-		}).should.throw();
 	});
 	it("should fail on wrong type", function() {
 		var fs = new MemoryFileSystem();


### PR DESCRIPTION
Fixes https://github.com/webpack/memory-fs/issues/57

This aligns `memory-fs` with native `fs` behavior when it comes to empty/missing arguments for `writeFileSync`