### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/MemoryFileSystem.js
+++ b/lib/MemoryFileSystem.js
@@ -214,7 +214,7 @@ class MemoryFileSystem {
 		if(isDir(current[path[i]]))
 			throw new MemoryFileSystemError(errors.code.EISDIR, _path, "writeFile");
 		const encoding = typeof optionsOrEncoding === "object" ? optionsOrEncoding.encoding : optionsOrEncoding;
-		current[path[i]] = optionsOrEncoding || typeof content === "string" ? new Buffer(content, encoding) : content;
+		current[path[i]] = optionsOrEncoding || typeof content === "string" ? Buffer.from(content, encoding) : content;
 		return;
 	}
 
@@ -254,7 +254,7 @@ class MemoryFileSystem {
 		let stream = new WritableStream();
 		try {
 			// Zero the file and make sure it is writable
-			this.writeFileSync(path, new Buffer(0));
+			this.writeFileSync(path, Buffer.alloc(0));
 		} catch(e) {
 			// This or setImmediate?
 			stream.once('prefinish', function() {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "travis": "npm run cover -- --report lcovonly && npm run lint"
   },
   "engines": {
-    "node": ">=4.3.0 <5.0.0 || >=5.10"
+    "node": ">=4.5.0 <5.0.0 || >=5.10"
   },
   "repository": {
     "type": "git",

--- a/test/MemoryFileSystem.js
+++ b/test/MemoryFileSystem.js
@@ -77,7 +77,7 @@ describe("files", function() {
 	it("should make and remove files", function() {
 		var fs = new MemoryFileSystem();
 		fs.mkdirSync("/test");
-		var buf = new Buffer("Hello World", "utf-8");
+		var buf = Buffer.from("Hello World", "utf-8");
 		fs.writeFileSync("/test/hello-world.txt", buf);
 		fs.readFileSync("/test/hello-world.txt").should.be.eql(buf);
 		fs.readFileSync("/test/hello-world.txt", "utf-8").should.be.eql("Hello World");
@@ -242,7 +242,7 @@ describe("async", function() {
 						content.should.be.eql("Hello");
 						fs.readFile("/test/dir/b", function(err, content) {
 							if(err) throw err;
-							content.should.be.eql(new Buffer("World"));
+							content.should.be.eql(Buffer.from("World"));
 							fs.exists("/test/dir/b", function(exists) {
 								exists.should.be.eql(true);
 								done();
@@ -279,7 +279,7 @@ describe("streams", function() {
 		it("should accept pipes", function(done) {
 			// TODO: Any way to avoid the asyncness of this?
 			var fs = new MemoryFileSystem();
-			bl(new Buffer("Hello"))
+			bl(Buffer.from("Hello"))
 				.pipe(fs.createWriteStream("/file"))
 				.once('finish', function() {
 					fs.readFileSync("/file", "utf8").should.be.eql("Hello");
@@ -417,20 +417,20 @@ describe("os", function() {
 			"": true,
 			a: {
 				"": true,
-				index: new Buffer("1"), // /a/index
+				index: Buffer.from("1"), // /a/index
 				dir: {
 					"": true,
-					index: new Buffer("2") // /a/dir/index
+					index: Buffer.from("2") // /a/dir/index
 				}
 			},
 			"C:": {
 				"": true,
 				a: {
 					"": true,
-					index: new Buffer("3"),  // C:\files\index
+					index: Buffer.from("3"),  // C:\files\index
 					dir: {
 						"": true,
-						index: new Buffer("4")  // C:\files\a\index
+						index: Buffer.from("4")  // C:\files\a\index
 					}
 				}
 			}


### PR DESCRIPTION
Use Buffer.from/Buffer.alloc instead.

This bumps the minimal Node.js version from 4.3.0 to 4.5.0,
but Node.js v4.x.x is long unsupported by upstream.

Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Refs: https://github.com/nodejs/node/pull/21351

/cc @sokra 