### PR TITLE
Add deprecate message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # memory-fs
 
+> DEPRECATED: use [memfs](https://github.com/streamich/memfs) instead.
+
 A simple in-memory filesystem. Holds data in a javascript object.
 
 ``` javascript


### PR DESCRIPTION
Still maintainers should deprecate the package on npm:

```
npm deprecate 'memory-fs' "This package is not maintained. You should to use `memfs` instead."
```

closes #77
closes #80
closes #81
closes #72